### PR TITLE
Update dependabot to daily checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
     directory: "/"
     open-pull-requests-limit: 3
     schedule:
-      interval: "weekly"
+      interval: "daily"
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "nuget"
+  - package-ecosystem: "daily"
     # location of package manifests
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Update Dependabot to daily checks, for security reasons get always the latest updates.